### PR TITLE
Support for looser regular expression patterns in task lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.0.5
+- Fixed a problem in which a task list was not regarded as a task list if the parentheses begin at the beginning of the task list description
+
 ## v0.0.4
 - Fix bug with tasklist in comment-out
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tasklist",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "authors": [
     "Ryo Nakamura <r7kamura@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tasklist.js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Convert tasklist in Markdown.",
   "main": "src/tasklist.js",
   "scripts": {

--- a/src/tasklist.js
+++ b/src/tasklist.js
@@ -4,7 +4,7 @@
   tasklist.codeBlockPattern = /^(`{3}(?:.+)?\n)([\S\s]*?)(\n`{3})$/gm;
   tasklist.commentPattern = /^([\s]*<!--)([\S\s]*?)(-->[^\n]*)$/gm;
 
-  tasklist.linePattern = /^(?:\s*(?:>\s*)*(?:[-+*]|(?:\d+\.)))\s*(\[ \]|\[x\])\s+(?!\(.*?\))(?=(?:\[.*?\]\s*(?:\[.*?\]|\(.*?\))\s*)*(?:[^\[]|$))/;
+  tasklist.linePattern = /^(?:\s*(?:>\s*)*(?:[-+*]|(?:\d+\.)))\s*(\[ \]|\[x\])\s+(?=(?:\[.*?\]\s*(?:\[.*?\]|\(.*?\))\s*)*(?:[^\[]|$))/;
 
   // ## tasklist.convert(String, Integer, Boolean)
   // Takes Markdown text, checkbox index that starts from 1, and checked flag,

--- a/test/tasklist_test.js
+++ b/test/tasklist_test.js
@@ -48,6 +48,37 @@ describe('tasklist', function () {
       });
     });
 
+    context('with list of links', function () {
+      it('does not confuse the links with checkboxes', function () {
+        assert.equal(
+          tasklist.convert(
+            '- [x](/inline/link)\n' +
+            '- [x] (Checkbox-note)\n' +
+            '- [x][reference-link]\n' +
+            '- [x] [reference-link]\n' +
+            '- [x][]\n' +
+            '- [x] []\n' +
+            '- [x] Checkbox\n' +
+            '\n' +
+            '[reference-link]: http://qiita.com/\n' +
+            '[x]: http://qiita.com/\n',
+            2,
+            false
+          ),
+          '- [x](/inline/link)\n' +
+          '- [x] (Checkbox-note)\n' +
+          '- [x][reference-link]\n' +
+          '- [x] [reference-link]\n' +
+          '- [x][]\n' +
+          '- [x] []\n' +
+          '- [ ] Checkbox\n' +
+          '\n' +
+          '[reference-link]: http://qiita.com/\n' +
+          '[x]: http://qiita.com/\n'
+        );
+      });
+    });
+
     context('with code block', function () {
       it('ignores tasklist in code block', function () {
         assert.equal(


### PR DESCRIPTION
Fixed a problem in which a task list was not regarded as a task list if the parentheses begin at the beginning of the task list description.